### PR TITLE
Fix the bug for edit limit walkthrough 

### DIFF
--- a/src/main/java/seedu/finbro/commands/EditLimitCommand.java
+++ b/src/main/java/seedu/finbro/commands/EditLimitCommand.java
@@ -21,56 +21,59 @@ public class EditLimitCommand extends Command {
 
         logger.log(Level.INFO, "Starting EditLimitCommand. Current limit: {0}", currentLimit);
 
-        ui.showLimitEditMenu(currentLimit);
-        String choice = ui.readCommand();
-        assert choice != null : "User input (choice) should not be null";
-
-        choice = choice.trim();
-        logger.log(Level.INFO, "User selected option: {0}", choice);
-
         double newLimit;
+        while (true) {
+            ui.showLimitEditMenu(currentLimit);
+            String choice = ui.readCommand();
+            assert choice != null : "User input (choice) should not be null";
 
-        switch (choice) {
-        case "1":
-            logger.log(Level.INFO, "User chose to increase limit");
-            ui.showEnterAmountPrompt("increase");
+            choice = choice.trim();
+            logger.log(Level.INFO, "User selected option: {0}", choice);
 
-            double increase = parsePositiveAmount(ui.readCommand().trim());
-            assert increase >= 0 : "Increase amount should be non-negative";
+            switch (choice) {
+            case "1":
+                logger.log(Level.INFO, "User chose to increase limit");
+                ui.showEnterAmountPrompt("increase");
 
-            logger.log(Level.INFO, "Increase amount entered: {0}", increase);
-            newLimit = currentLimit + increase;
-            break;
+                double increase = parsePositiveAmount(ui.readCommand().trim());
+                assert increase >= 0 : "Increase amount should be non-negative";
 
-        case "2":
-            logger.log(Level.INFO, "User chose to decrease limit");
-            ui.showEnterAmountPrompt("decrease");
+                logger.log(Level.INFO, "Increase amount entered: {0}", increase);
+                newLimit = currentLimit + increase;
+                break;
 
-            double decrease = parsePositiveAmount(ui.readCommand().trim());
-            assert decrease >= 0 : "Decrease amount should be non-negative";
+            case "2":
+                logger.log(Level.INFO, "User chose to decrease limit");
+                ui.showEnterAmountPrompt("decrease");
 
-            logger.log(Level.INFO, "Decrease amount entered: {0}", decrease);
-            newLimit = currentLimit - decrease;
+                double decrease = parsePositiveAmount(ui.readCommand().trim());
+                assert decrease >= 0 : "Decrease amount should be non-negative";
 
-            if (newLimit < 0) {
-                logger.log(Level.WARNING, "Invalid operation: resulting limit is negative ({0})", newLimit);
-                throw new FinbroException("Monthly spending limit must be at least $0");
+                logger.log(Level.INFO, "Decrease amount entered: {0}", decrease);
+                newLimit = currentLimit - decrease;
+
+                if (newLimit < 0) {
+                    logger.log(Level.WARNING, "Invalid operation: resulting limit is negative ({0})", newLimit);
+                    throw new FinbroException("Monthly spending limit must be at least $0");
+                }
+                break;
+
+            case "3":
+                logger.log(Level.INFO, "User chose to replace limit");
+                ui.showEnterAmountPrompt("replace");
+
+                newLimit = parsePositiveAmount(ui.readCommand().trim());
+                assert newLimit >= 0 : "Replacement limit should be non-negative";
+
+                logger.log(Level.INFO, "Replacement amount entered: {0}", newLimit);
+                break;
+
+            default:
+                logger.log(Level.WARNING, "Invalid menu choice entered: {0}", choice);
+                ui.showInlineError("Please enter 1, 2, or 3.");
+                continue;
             }
             break;
-
-        case "3":
-            logger.log(Level.INFO, "User chose to replace limit");
-            ui.showEnterAmountPrompt("replace");
-
-            newLimit = parsePositiveAmount(ui.readCommand().trim());
-            assert newLimit >= 0 : "Replacement limit should be non-negative";
-
-            logger.log(Level.INFO, "Replacement amount entered: {0}", newLimit);
-            break;
-
-        default:
-            logger.log(Level.WARNING, "Invalid menu choice entered: {0}", choice);
-            throw new FinbroException("Please enter 1, 2, or 3.");
         }
         assert newLimit >= 0 : "Final limit should never be negative";
 

--- a/src/test/java/seedu/finbro/commands/EditLimitCommandTest.java
+++ b/src/test/java/seedu/finbro/commands/EditLimitCommandTest.java
@@ -64,7 +64,7 @@ public class EditLimitCommandTest {
 
     //@@author WangZX2001
     @Test
-    public void execute_invalidMenuChoice_secondChance_success() throws FinbroException {
+    public void execute_invalidChoice_retriesSuccessfully() throws FinbroException {
         ExpenseList expenses = new ExpenseList();
         TestUi ui = new TestUi();
         Storage storage = new Storage(TEST_FILE_PATH);

--- a/src/test/java/seedu/finbro/commands/EditLimitCommandTest.java
+++ b/src/test/java/seedu/finbro/commands/EditLimitCommandTest.java
@@ -64,21 +64,18 @@ public class EditLimitCommandTest {
 
     //@@author WangZX2001
     @Test
-    public void execute_invalidMenuChoice_exceptionThrown() {
+    public void execute_invalidMenuChoice_secondChance_success() throws FinbroException {
         ExpenseList expenses = new ExpenseList();
         TestUi ui = new TestUi();
         Storage storage = new Storage(TEST_FILE_PATH);
 
-        ui.setInputs("4");
+        ui.setInputs("4", "1", "100", "yes");
         Limit.setLimit(500.0);
 
         EditLimitCommand command = new EditLimitCommand();
+        command.execute(expenses, ui, storage);
 
-        FinbroException exception = assertThrows(FinbroException.class,
-                () -> command.execute(expenses, ui, storage));
-
-        assertEquals("Please enter 1, 2, or 3.", exception.getMessage());
-        assertEquals(500.0, Limit.getLimit());
+        assertEquals(600.0, Limit.getLimit());
     }
 
     //@@author WangZX2001


### PR DESCRIPTION
When user enter a invalid number option, the program will not crash but instead ask user for a new input