### PR TITLE
Enhance error message for supported sorts

### DIFF
--- a/src/main/java/seedu/finbro/commands/ViewCommand.java
+++ b/src/main/java/seedu/finbro/commands/ViewCommand.java
@@ -54,7 +54,8 @@ public class ViewCommand extends Command {
 
         if (parsedArg.sortType() != null && !SortService.isValidSortType(parsedArg.sortType())) {
             throw new FinbroException("Invalid sort type: " + parsedArg.sortType()
-                    + "\nSupported sorts: year, month, category, amount");
+                    + "\nSupported sorts: year, month, category, amount" +
+                    "\nNote: category is unavailable for \"view <category>\".");
         }
 
         if (ALL.equals(parsedArg.target())) {

--- a/src/test/java/seedu/finbro/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/finbro/commands/ViewCommandTest.java
@@ -267,8 +267,10 @@ public class ViewCommandTest {
         FinbroException exception = assertThrows(FinbroException.class,
                 () -> new ViewCommand("all -sort six-seven").execute(expenses, ui, null));
 
-        assertEquals("Invalid sort type: six-seven\nSupported sorts: year, month, category, amount",
-                exception.getMessage());
+        assertEquals("""
+                Invalid sort type: six-seven
+                Supported sorts: year, month, category, amount
+                Note: category is unavailable for "view <category>".""", exception.getMessage());
     }
 
     //@@author AK47ofCode


### PR DESCRIPTION
The previous error message was misleading because it included category as a supported sort option in a category-specific view, even though the help text states that category sorting is only for view all, which confused users about which sort options are actually valid for view.

Fix error message to state that the category sort option is unavailable for "view <category>".

Additionally, tweaked a test to correctly test and pass this change.

Resolve #129 